### PR TITLE
Batch Calculation Optimisation 10-12x Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ To run the example, you must have the AWS CLI set up. Your credentials must have
 1. Create your S3 bucket to store the intermediaries and result
 (remember to use your own bucket name due to S3 namespace)
 
-  $ aws s3 mb s3://biglambda-s3-bucket
+  $ aws s3 mb s3://YOUR-BUCKET-NAME-HERE
 
 2. Update the policy.json with your S3 bucket name
 
-  $ sed -i 's/s3:::MY-S3-BUCKET/s3:::biglambda-s3-bucket/' policy.json
+  $ sed -i 's/s3:::YOUR-BUCKET-NAME-HERE/s3:::biglambda-s3-bucket/' policy.json
 
 3. Create the IAM role with respective policy
 
@@ -69,7 +69,7 @@ For the jobBucket field, enter an S3 bucket in your account that you wish to use
 {
         "bucket": "big-data-benchmark",
         "prefix": "pavlo/text/1node/uservisits/",
-        "jobBucket": "biglambda-s3-bucket",
+        "jobBucket": "YOUR-BUCKET-NAME-HERE",
         "concurrentLambdas": 100,
         "mapper": {
             "name": "mapper.py",

--- a/src/python/driver.py
+++ b/src/python/driver.py
@@ -92,9 +92,10 @@ region = config["region"]
 lambda_memory = config["lambdaMemory"]
 concurrent_lambdas = config["concurrentLambdas"]
 lambda_read_timeout = config["lambda_read_timeout"]
+boto_max_connections = config["boto_max_connections"]
 
 # Setting longer timeout for reading lambda results and larger connections pool
-lambda_config = Config(read_timeout=lambda_read_timeout, max_pool_connections=50)
+lambda_config = Config(read_timeout=lambda_read_timeout, max_pool_connections=boto_max_connections)
 lambda_client = boto3.client('lambda', config=lambda_config)
 
 # Fetch all the keys that match the prefix

--- a/src/python/driver.py
+++ b/src/python/driver.py
@@ -103,7 +103,7 @@ all_keys = []
 for obj in s3.Bucket(bucket).objects.filter(Prefix=config["prefix"]).all():
     all_keys.append(obj)
 
-bsize = lambdautils.compute_batch_size(all_keys, lambda_memory)
+bsize = lambdautils.compute_batch_size(all_keys, lambda_memory, concurrent_lambdas)
 batches = lambdautils.batch_creator(all_keys, bsize)
 n_mappers = len(batches)
 document = xray_recorder.current_subsegment()

--- a/src/python/driverconfig.json
+++ b/src/python/driverconfig.json
@@ -1,11 +1,12 @@
 {
       "bucket": "big-data-benchmark",
       "prefix": "pavlo/text/1node/uservisits/",
-      "jobBucket": "smallya-useast-1",
+      "jobBucket": "aws-bigdata-mapreduce-sr18",
       "region": "us-east-1",
       "lambdaMemory": 1536,
-      "concurrentLambdas": 100,
+      "concurrentLambdas": 1000,
       "lambda_read_timeout": 300,
+      "boto_max_connections": 1000,
       "mapper": {
             "name": "mapper.py",
             "handler": "mapper.lambda_handler",

--- a/src/python/driverconfig.json
+++ b/src/python/driverconfig.json
@@ -1,7 +1,7 @@
 {
       "bucket": "big-data-benchmark",
       "prefix": "pavlo/text/1node/uservisits/",
-      "jobBucket": "aws-bigdata-mapreduce-sr18",
+      "jobBucket": "ENTER YOUR BUCKET HERE",
       "region": "us-east-1",
       "lambdaMemory": 1536,
       "concurrentLambdas": 1000,

--- a/src/python/jobinfo.json
+++ b/src/python/jobinfo.json
@@ -1,6 +1,6 @@
 {
-    "jobBucket": "smallya-useast-1", 
-    "mapCount": 29, 
+    "jobBucket": "aws-bigdata-mapreduce-sr18", 
+    "mapCount": 202, 
     "reducerFunction": "BL-reducer-bl-release", 
     "reducerHandler": "reducer.lambda_handler", 
     "jobId": "bl-release"

--- a/src/python/reducerCoordinator.py
+++ b/src/python/reducerCoordinator.py
@@ -60,7 +60,7 @@ def get_mapper_files(files):
 
 def get_reducer_batch_size(keys):
     #TODO: Paramertize memory size
-    batch_size = lambdautils.compute_batch_size(keys, 1536)
+    batch_size = lambdautils.compute_batch_size(keys, 1536, 1000)
     return max(batch_size, 2) # At least 2 in a batch - Condition for termination
 
 def check_job_done(files):


### PR DESCRIPTION
Batch calculations were hard coded to push as many keys as possible into a single lambda. The updated batch calculation takes the following variables into account:

**Batch Calculation**
- Lambda Concurrency
- Lambda maximum usable memory size
- The number of keys

These are now configurable in `driverconfig.json` and will allow workloads much larger than the single node **AMPLABS benchmark**.

**Configuration Changes**

_Boto Connection Pool_
To maximise throughput of `BOTO3` lambda creation, I have added a configurable connection pool to avoid connections blocking until another is available.

_Default Results Bucket_
After feedback from several users, I have changed the default result S3 bucket away from Sunil's original to a generic `ENTER YOUR BUCKET HERE` after several people failed to deploy due to the bucket configuration.

_Lambda Concurrency_
The default concurrent lambda executions per account has been changed from 100, to 1000 for all AWS users. I have set this default in the configuration file.

_X-Ray Support disabled by Default_
I have disabled AWS X-Ray support by default. This required everyone to configure local x-ray support even if you were not using the library. Therefore we will set the default to `PassThrough` to avoid that overhead.

